### PR TITLE
Remove softlink instructions for torch include directory

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -18,7 +18,7 @@ IndentWidth: 2
 TabWidth: 2
 ContinuationIndentWidth: 4
 AccessModifierOffset: -1 # The private/protected/public has no indent in class
-Standard: Cpp11
+Standard: Cpp17
 AllowAllParametersOfDeclarationOnNextLine: true
 BinPackParameters: false
 BinPackArguments: false

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,26 @@
+# The clang-format is part of llvm toolchain.
+# It need to install llvm and clang to format source code style.
+#
+# The basic usage is,
+#   clang-format -i -style=file PATH/TO/SOURCE/CODE
+#
+# The -style=file implicit use ".clang-format" file located in one of
+# parent directory.
+# The -i means inplace change.
+#
+# The document of clang-format is
+#   http://clang.llvm.org/docs/ClangFormat.html
+#   http://clang.llvm.org/docs/ClangFormatStyleOptions.html
+---
+Language: Cpp
+BasedOnStyle: Google
+IndentWidth: 2
+TabWidth: 2
+ContinuationIndentWidth: 4
+AccessModifierOffset: -1 # The private/protected/public has no indent in class
+Standard: Cpp11
+AllowAllParametersOfDeclarationOnNextLine: true
+BinPackParameters: false
+BinPackArguments: false
+IncludeBlocks: Preserve
+IncludeIsMainSourceRegex: (\.cu)$

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "cmake.sourceDirectory": "${workspaceFolder}/csrc",
+  "cmake.sourceDirectory": "${workspaceFolder}/csrc"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cmake.sourceDirectory": "/home/zgong6/repos/tiberate/csrc"
+    "cmake.sourceDirectory": "${workspaceFolder}/csrc",
 }

--- a/csrc/.clangd
+++ b/csrc/.clangd
@@ -1,17 +1,29 @@
 CompileFlags:
-  Remove:
-    - "--expt-extended-lambda"
-    - '-gencode=arch=compute_60,code="sm_60,compute_60"'
-    - "-rdc=true"
-    - "-forward-unknown-to-host-compiler"
-    - "--expt-relaxed-constexpr"
-    - "--generate-code=arch=compute_52,code=[compute_52,sm_52]"
-    - "-arch=native"
-    - "--options-file"
-    - "-Xcompiler=-fPIC"
-  Add:
-    - "-x"
-    - "cuda"
-    - "--cuda-gpu-arch=sm_80"
-    - "-std=c++17"
   Compiler: clang++
+  CompilationDatabase: .
+  Add:
+    - -x
+    - cuda
+    - "-std=c++17"
+    - "--cuda-gpu-arch=sm_86"
+  Remove:
+    # strip CUDA fatbin args
+    - "-Xfatbin*"
+    - "-Xcompiler*"
+    - "-Xcudafe*"
+    - "-rdc=*"
+    - "-gpu=*"
+    - "--diag_suppress*"
+    # strip CUDA arch flags
+    - "-gencode*"
+    - "--generate-code*"
+    # strip gcc's -fcoroutines
+    - -fcoroutines
+    # strip CUDA flags unknown to clang
+    - "-rdc=true"
+    - "-ccbin*"
+    - "--compiler-options*"
+    - "--expt-extended-lambda"
+    - "--expt-relaxed-constexpr"
+    - "-forward-unknown-to-host-compiler"
+    - "-Werror=cross-execution-space-call"

--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -1,17 +1,28 @@
 cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(tiberate-csrc)
 
-# ```bash
-# ln -s $(python -c "import torch; import os; print(os.path.abspath(os.path.join(torch.utils.cmake_prefix_path, '../../')))") ./libtorch
-# ```
+execute_process(
+    COMMAND ${Python_EXECUTABLE} -c "import torch; print(torch.utils.cmake_perfix_path)"
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE TORCH_CMAKE_PATH
+)
 
-list(APPEND CMAKE_PREFIX_PATH "libtorch")
+list(APPEND CMAKE_PREFIX_PATH ${TORCH_CMAKE_PATH})
 
-find_package(Python 3 COMPONENTS Interpreter Development REQUIRED)
+find_package(Python COMPONENTS Interpreter Development REQUIRED)
 find_package(Torch REQUIRED)
 find_package(CUDA REQUIRED)
 find_package(pybind11 REQUIRED)
 
+include_directories(
+    ${Python_INCLUDE_DIRS}
+    ${TORCH_INCLUDE_DIRS}
+)
+
+message(STATUS "Python include dirs: ${Python_INCLUDE_DIRS}")
+message(STATUS "Torch include dirs: ${TORCH_INCLUDE_DIRS}")
+
+set(CMAKE_CUDA_USE_RESPONSE_FILE_FOR_INCLUDES OFF)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
 
 add_library(randint_cuda SHARED

--- a/csrc/readme.md
+++ b/csrc/readme.md
@@ -11,12 +11,6 @@ conda activate <your_env>
 conda install cmake
 ```
 
-## softlink torch include dir
-
-```bash
-ln -s $(python -c "import torch; import os; print(os.path.abspath(os.path.join(torch.utils.cmake_prefix_path, '../../')))") ./libtorch
-```
-
 ## generate compile_commands.json
 
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ import pathlib
 import shutil
 
 from setuptools import setup
-from setuptools.command.install import install
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
1. ~~You know what I mean~~
2. May fix Python.h missing by `include_directories`?
3. Recommend using clang-format

